### PR TITLE
Add JSON-linting step to CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,8 +23,8 @@ before_script:
 security_checks:
   extends: .tests
   before_script:
-      - virtualenv ~/venv
-      - source ~/venv/bin/activate
+    - virtualenv ~/venv
+    - source ~/venv/bin/activate
   script:
     - pip install trufflehog
     - wget -O regex.json https://raw.githubusercontent.com/HumanCellAtlas/dcplib/master/components/trufflehog_regex_patterns.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,7 @@ json_lint:
   extends: .tests
   script:
     - python -m json.tool ./config/groups.json > /dev/null || exit 1
+    - python -m json.tool ./config/roles.json > /dev/null || exit 1
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,11 @@ security_checks:
     - trufflehog --regex --rules regex.json --entropy=False https://github.com/HumanCellAtlas/fusillade.git
     - rm regex.json
 
+json_lint:
+  extends: .tests
+  script:
+    - python -m json.tool ./config/groups.json > /dev/null || exit 1
+
 deploy:
   stage: deploy
   script:


### PR DESCRIPTION
This adds a JSON-linting step for the configuration files in `config/` before they are applied with the `setup_fusillade.py` script.

Once this change is merged into `master` we will need to update `.gitlab-ci.yml` on all other deployment branches on Allspark.